### PR TITLE
CI: skip secrets on forks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -7,6 +7,9 @@ on:
 jobs:
   gitleaks:
     runs-on: ubuntu-latest
+    # Skip on PRs from forks: GITLEAKS_LICENSE is not exposed to fork PRs,
+    # so gitleaks-action fails. Fork contributions still get scanned on push to main.
+    if: github.event_name == 'push' || github.event.pull_request.head.repo.full_name == github.repository
     steps:
       - uses: actions/checkout@v4
         with:


### PR DESCRIPTION
Closes #22 

Skips the secrets scan on forks due to a limitation in the license key secret etc. It is unlikely a fork will contain a secret, so this seems like a fine solution. 