### PR TITLE
Rate Limit: Remove dup extractkey

### DIFF
--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -14,16 +14,16 @@ type Verifier interface {
 
 type ctxKey struct{}
 
-// WithKey returns ctx carrying key, so downstream middleware can read the
-// verified API key without re-parsing request headers.
-func WithKey(ctx context.Context, key string) context.Context {
-	return context.WithValue(ctx, ctxKey{}, key)
-}
-
 // KeyFromContext returns the verified API key set by Require, or "" if absent.
+// Only Require populates this value; the setter is intentionally unexported so
+// downstream middleware cannot be fooled by callers stashing arbitrary strings.
 func KeyFromContext(ctx context.Context) string {
 	s, _ := ctx.Value(ctxKey{}).(string)
 	return s
+}
+
+func withKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, key)
 }
 
 // Require returns middleware that rejects requests without a valid API key
@@ -39,7 +39,7 @@ func Require(v Verifier) func(http.Handler) http.Handler {
 			}
 			switch err := v.Verify(key); {
 			case err == nil:
-				next.ServeHTTP(w, r.WithContext(WithKey(r.Context(), key)))
+				next.ServeHTTP(w, r.WithContext(withKey(r.Context(), key)))
 			case errors.Is(err, ErrInvalidKey):
 				unauthorized(w, "invalid api key")
 			default:

--- a/internal/auth/middleware.go
+++ b/internal/auth/middleware.go
@@ -1,6 +1,7 @@
 package auth
 
 import (
+	"context"
 	"errors"
 	"log"
 	"net/http"
@@ -11,7 +12,22 @@ type Verifier interface {
 	Verify(raw string) error
 }
 
-// Require returns middleware that rejects requests without a valid API key.
+type ctxKey struct{}
+
+// WithKey returns ctx carrying key, so downstream middleware can read the
+// verified API key without re-parsing request headers.
+func WithKey(ctx context.Context, key string) context.Context {
+	return context.WithValue(ctx, ctxKey{}, key)
+}
+
+// KeyFromContext returns the verified API key set by Require, or "" if absent.
+func KeyFromContext(ctx context.Context) string {
+	s, _ := ctx.Value(ctxKey{}).(string)
+	return s
+}
+
+// Require returns middleware that rejects requests without a valid API key
+// and stashes the verified key on the request context for downstream handlers.
 // Keys are accepted in either "Authorization: Bearer <key>" or "X-API-Key: <key>".
 func Require(v Verifier) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
@@ -23,7 +39,7 @@ func Require(v Verifier) func(http.Handler) http.Handler {
 			}
 			switch err := v.Verify(key); {
 			case err == nil:
-				next.ServeHTTP(w, r)
+				next.ServeHTTP(w, r.WithContext(WithKey(r.Context(), key)))
 			case errors.Is(err, ErrInvalidKey):
 				unauthorized(w, "invalid api key")
 			default:

--- a/internal/ratelimit/ratelimit.go
+++ b/internal/ratelimit/ratelimit.go
@@ -3,9 +3,9 @@ package ratelimit
 
 import (
 	"net/http"
-	"strings"
 	"sync"
 
+	"github.com/Ribbit-Network/api/internal/auth"
 	"golang.org/x/time/rate"
 )
 
@@ -26,13 +26,12 @@ func New(r rate.Limit, b int) *Limiter {
 	}
 }
 
-// Middleware returns HTTP middleware that rate-limits by API key.
-// Keys are read from "Authorization: Bearer <key>" or "X-API-Key: <key>",
-// matching the auth middleware extraction logic. Requests with no key
-// are passed through — the auth middleware upstream handles rejection.
+// Middleware returns HTTP middleware that rate-limits by API key, reading the
+// key from the request context (set by auth.Require). Requests without a key
+// pass through — the auth middleware upstream is responsible for rejecting them.
 func (l *Limiter) Middleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		key := extractKey(r)
+		key := auth.KeyFromContext(r.Context())
 		if key != "" && !l.get(key).Allow() {
 			http.Error(w, "rate limit exceeded", http.StatusTooManyRequests)
 			return
@@ -50,13 +49,4 @@ func (l *Limiter) get(key string) *rate.Limiter {
 		l.entries[key] = lim
 	}
 	return lim
-}
-
-func extractKey(r *http.Request) string {
-	if h := r.Header.Get("Authorization"); h != "" {
-		if rest, ok := strings.CutPrefix(h, "Bearer "); ok {
-			return strings.TrimSpace(rest)
-		}
-	}
-	return strings.TrimSpace(r.Header.Get("X-API-Key"))
 }

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -5,6 +5,7 @@ import (
 	"net/http/httptest"
 	"testing"
 
+	"github.com/Ribbit-Network/api/internal/auth"
 	"github.com/stretchr/testify/require"
 	"golang.org/x/time/rate"
 )
@@ -15,15 +16,21 @@ func okHandler() http.Handler {
 	})
 }
 
+func requestWithKey(key string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	if key != "" {
+		req = req.WithContext(auth.WithKey(req.Context(), key))
+	}
+	return req
+}
+
 func TestRateLimit_AllowsWithinBurst(t *testing.T) {
 	l := New(rate.Limit(1), 5)
 	h := l.Middleware(okHandler())
 
 	for i := 0; i < 5; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/data", nil)
-		req.Header.Set("X-API-Key", "testkey")
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
+		h.ServeHTTP(rec, requestWithKey("testkey"))
 		require.Equal(t, http.StatusOK, rec.Code, "request %d should be allowed", i+1)
 	}
 }
@@ -33,17 +40,13 @@ func TestRateLimit_BlocksAfterBurst(t *testing.T) {
 	h := l.Middleware(okHandler())
 
 	for i := 0; i < 3; i++ {
-		req := httptest.NewRequest(http.MethodGet, "/data", nil)
-		req.Header.Set("X-API-Key", "testkey")
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
+		h.ServeHTTP(rec, requestWithKey("testkey"))
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
 
-	req := httptest.NewRequest(http.MethodGet, "/data", nil)
-	req.Header.Set("X-API-Key", "testkey")
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+	h.ServeHTTP(rec, requestWithKey("testkey"))
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 }
 
@@ -52,37 +55,17 @@ func TestRateLimit_IndependentPerKey(t *testing.T) {
 	h := l.Middleware(okHandler())
 
 	for _, key := range []string{"key-a", "key-b", "key-c"} {
-		req := httptest.NewRequest(http.MethodGet, "/data", nil)
-		req.Header.Set("X-API-Key", key)
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, req)
+		h.ServeHTTP(rec, requestWithKey(key))
 		require.Equal(t, http.StatusOK, rec.Code, "first request for %s should pass", key)
 	}
-}
-
-func TestRateLimit_BearerToken(t *testing.T) {
-	l := New(rate.Limit(1), 1)
-	h := l.Middleware(okHandler())
-
-	req := httptest.NewRequest(http.MethodGet, "/data", nil)
-	req.Header.Set("Authorization", "Bearer mytoken")
-	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
-	require.Equal(t, http.StatusOK, rec.Code)
-
-	req2 := httptest.NewRequest(http.MethodGet, "/data", nil)
-	req2.Header.Set("Authorization", "Bearer mytoken")
-	rec2 := httptest.NewRecorder()
-	h.ServeHTTP(rec2, req2)
-	require.Equal(t, http.StatusTooManyRequests, rec2.Code)
 }
 
 func TestRateLimit_NoKey_PassesThrough(t *testing.T) {
 	l := New(rate.Limit(1), 1)
 	h := l.Middleware(okHandler())
 
-	req := httptest.NewRequest(http.MethodGet, "/data", nil)
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, req)
+	h.ServeHTTP(rec, requestWithKey(""))
 	require.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -10,62 +10,69 @@ import (
 	"golang.org/x/time/rate"
 )
 
+// allowAll is a permissive auth.Verifier for tests — every key is valid.
+// Combined with auth.Require, this is how tests populate the context-stashed
+// key that Limiter.Middleware reads.
+type allowAll struct{}
+
+func (allowAll) Verify(string) error { return nil }
+
 func okHandler() http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusOK)
 	})
 }
 
-func requestWithKey(key string) *http.Request {
+func limited(l *Limiter) http.Handler {
+	return auth.Require(allowAll{})(l.Middleware(okHandler()))
+}
+
+func reqWithKey(key string) *http.Request {
 	req := httptest.NewRequest(http.MethodGet, "/data", nil)
-	if key != "" {
-		req = req.WithContext(auth.WithKey(req.Context(), key))
-	}
+	req.Header.Set("X-API-Key", key)
 	return req
 }
 
 func TestRateLimit_AllowsWithinBurst(t *testing.T) {
-	l := New(rate.Limit(1), 5)
-	h := l.Middleware(okHandler())
+	h := limited(New(rate.Limit(1), 5))
 
 	for i := 0; i < 5; i++ {
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, requestWithKey("testkey"))
+		h.ServeHTTP(rec, reqWithKey("testkey"))
 		require.Equal(t, http.StatusOK, rec.Code, "request %d should be allowed", i+1)
 	}
 }
 
 func TestRateLimit_BlocksAfterBurst(t *testing.T) {
-	l := New(rate.Limit(1), 3)
-	h := l.Middleware(okHandler())
+	h := limited(New(rate.Limit(1), 3))
 
 	for i := 0; i < 3; i++ {
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, requestWithKey("testkey"))
+		h.ServeHTTP(rec, reqWithKey("testkey"))
 		require.Equal(t, http.StatusOK, rec.Code)
 	}
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, requestWithKey("testkey"))
+	h.ServeHTTP(rec, reqWithKey("testkey"))
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 }
 
 func TestRateLimit_IndependentPerKey(t *testing.T) {
-	l := New(rate.Limit(1), 1)
-	h := l.Middleware(okHandler())
+	h := limited(New(rate.Limit(1), 1))
 
 	for _, key := range []string{"key-a", "key-b", "key-c"} {
 		rec := httptest.NewRecorder()
-		h.ServeHTTP(rec, requestWithKey(key))
+		h.ServeHTTP(rec, reqWithKey(key))
 		require.Equal(t, http.StatusOK, rec.Code, "first request for %s should pass", key)
 	}
 }
 
-func TestRateLimit_NoKey_PassesThrough(t *testing.T) {
-	l := New(rate.Limit(1), 1)
-	h := l.Middleware(okHandler())
+// If something mounts Limiter.Middleware without auth in front, a request with
+// no context key should pass through rather than gate on an empty string.
+func TestRateLimit_NoKeyInContext_PassesThrough(t *testing.T) {
+	h := New(rate.Limit(1), 1).Middleware(okHandler())
 
 	rec := httptest.NewRecorder()
-	h.ServeHTTP(rec, requestWithKey(""))
+	h.ServeHTTP(rec, httptest.NewRequest(http.MethodGet, "/data", nil))
 	require.Equal(t, http.StatusOK, rec.Code)
 }

--- a/internal/ratelimit/ratelimit_test.go
+++ b/internal/ratelimit/ratelimit_test.go
@@ -33,6 +33,12 @@ func reqWithKey(key string) *http.Request {
 	return req
 }
 
+func reqWithBearer(key string) *http.Request {
+	req := httptest.NewRequest(http.MethodGet, "/data", nil)
+	req.Header.Set("Authorization", "Bearer "+key)
+	return req
+}
+
 func TestRateLimit_AllowsWithinBurst(t *testing.T) {
 	h := limited(New(rate.Limit(1), 5))
 
@@ -54,6 +60,23 @@ func TestRateLimit_BlocksAfterBurst(t *testing.T) {
 
 	rec := httptest.NewRecorder()
 	h.ServeHTTP(rec, reqWithKey("testkey"))
+	require.Equal(t, http.StatusTooManyRequests, rec.Code)
+}
+
+// Confirms the same rate-limit gate fires when the key arrives via
+// "Authorization: Bearer ..." instead of X-API-Key — i.e. the auth+ratelimit
+// chain works end-to-end regardless of which header the client uses.
+func TestRateLimit_BlocksAfterBurst_Bearer(t *testing.T) {
+	h := limited(New(rate.Limit(1), 2))
+
+	for i := 0; i < 2; i++ {
+		rec := httptest.NewRecorder()
+		h.ServeHTTP(rec, reqWithBearer("bearer-key"))
+		require.Equal(t, http.StatusOK, rec.Code)
+	}
+
+	rec := httptest.NewRecorder()
+	h.ServeHTTP(rec, reqWithBearer("bearer-key"))
 	require.Equal(t, http.StatusTooManyRequests, rec.Code)
 }
 


### PR DESCRIPTION
Closes #24 

There is a duplicated function extractKey.

This function appears to be a duplicate of the one in middleware.go

We should probably use the authentication layer. The auth should then stash the verified key in r.Context() and let ratelimit read it from there.